### PR TITLE
Adding arithmetic operation in Expression

### DIFF
--- a/Barrel.podspec
+++ b/Barrel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = "Barrel"
-    s.version      = "0.3.2"
+    s.version      = "0.4.0"
     s.summary      = "Type safe CoreData library."
     s.license      = { :type => 'MIT', :file => './LICENSE' }
     s.homepage     = "https://github.com/tarunon/Barrel"

--- a/Barrel/Aggregate.swift
+++ b/Barrel/Aggregate.swift
@@ -69,28 +69,13 @@ public extension Aggregate {
 
 // MARK: aggregate methods via attribute
 public extension Aggregate {
-    public func aggregate(expressionDescription:(ExpressionDescription<T>, T) -> ExpressionDescription<T>) -> Aggregate {
-        return aggregate(expressionDescription(ExpressionDescription(context: self.context), self.context.attribute()).expressionDescription())
-    }
-    
-    public func aggregate<E: ExpressionType>(expressionDescription:(ExpressionDescription<T>, T) -> E) -> Aggregate {
+    public func aggregate<E: ExpressionType>(expressionDescription:(T) -> E) -> Aggregate {
         return aggregate({ () -> NSExpressionDescription in
-            let description = ExpressionDescription<T>(context: self.context)
-            let result = Expression.createExpression(expressionDescription(description, self.context.attribute()))
-            return description.keyPath(result).expressionDescription()
+            return ExpressionDescription(argument: Expression.createExpression(expressionDescription(self.context.attribute()))).expressionDescription()
             }())
     }
     
-    public func groupBy<U>(keyPath: (T) -> U) -> Group<T> {
-        return Group(context: context, builder: builder, keyPath: {
-            if let attribute = (keyPath(self.context.attribute()) as? String)?.decodingProperty() {
-                return attribute.keyPath
-            }
-            return ""
-        }())
-    }
-    
-    public func groupBy<U>(keyPath: (T) -> Expression<U>) -> Group<T> {
-        return Group(context: context, builder: builder, keyPath: keyPath(self.context.attribute()).expression().keyPath)
+    public func groupBy<E: ExpressionType>(argument: (T) -> E) -> Group<T> {
+        return Group(context: context, builder: builder, keyPath: Expression.createExpression(argument(self.context.attribute())).name())
     }
 }

--- a/Barrel/Entity.swift
+++ b/Barrel/Entity.swift
@@ -68,13 +68,3 @@ internal extension NSManagedObjectContext {
         return NSEntityDescription.entityForName(entityName(T)!, inManagedObjectContext: self)
     }
 }
-
-internal extension NSAttributeType {
-    init(entityDescription: NSEntityDescription, keyPath: String) {
-        if let attribute = entityDescription.attributesByName[keyPath] as? NSAttributeDescription {
-            self = attribute.attributeType
-        } else {
-            self = .UndefinedAttributeType
-        }
-    }
-}

--- a/Barrel/Expression.swift
+++ b/Barrel/Expression.swift
@@ -27,6 +27,10 @@ extension Set: ExpressionType {
     typealias ValueType = Set
 }
 
+enum ExpressionFunction {
+    case Add
+}
+
 public struct Expression<V: ExpressionType>: ExpressionType {
     typealias ValueType = V.ValueType
     internal let builder: ExpressionBuilder
@@ -70,5 +74,9 @@ extension Expression: Builder {
     public func expression() -> NSExpression {
         return builder()
     }
+}
+
+public func +<E: ExpressionType>(lhs: E?, rhs: E?) -> Expression<E.ValueType> {
+    return Expression(builder: { NSExpression(forFunction: "add:to:", arguments: [Expression.createExpression(lhs).expression(), Expression.createExpression(rhs).expression()]) })
 }
 

--- a/Barrel/Expression.swift
+++ b/Barrel/Expression.swift
@@ -10,73 +10,183 @@ import Foundation
 import CoreData
 
 internal typealias ExpressionBuilder = () -> NSExpression
+internal typealias NameBuilder = () -> String
 
 public protocol ExpressionType {
     typealias ValueType: ExpressionType
 }
 
-extension NSObject: ExpressionType {
-    typealias ValueType = NSObject
+extension NSNumber: ExpressionType {
+    typealias ValueType = NSNumber
+}
+
+extension NSDate: ExpressionType {
+    typealias ValueType = NSDate
+}
+
+extension NSData: ExpressionType {
+    typealias ValueType = NSData
 }
 
 extension String: ExpressionType {
     typealias ValueType = String
 }
 
+extension NSSet: ExpressionType {
+    typealias ValueType = NSSet
+}
+
+extension NSManagedObject: ExpressionType {
+    typealias ValueType = NSManagedObject
+}
+
 extension Set: ExpressionType {
-    typealias ValueType = Set
+    typealias ValueType = NSSet
 }
 
-enum ExpressionFunction {
+internal extension NSAttributeType {
+    init<E: ExpressionType>(type: E.Type) {
+        if let _ = E.ValueType.self as? NSNumber.Type {
+            self = .DoubleAttributeType
+        } else if let _ = E.ValueType.self as? String.Type {
+            self = .StringAttributeType
+        } else if let _ = E.ValueType.self as? NSDate.Type {
+            self = .DateAttributeType
+        } else if let _ = E.ValueType.self as? NSData.Type {
+            self = .BinaryDataAttributeType
+        } else {
+            self = .UndefinedAttributeType
+        }
+    }
+}
+
+enum ExpressionFunctionType {
     case Add
+    case Subtract
+    case Multiply
+    case Divide
+    case Max
+    case Min
+    case Sum
+    case Average
+    case Count
+    
+    internal func function() -> String {
+        switch self {
+        case .Add:
+            return "add:to:"
+        case .Subtract:
+            return "from:subtract:"
+        case .Multiply:
+            return "multiply:by:"
+        case .Divide:
+            return "divide:by:"
+        case .Max:
+            return "max:"
+        case .Min:
+            return "min:"
+        case .Count:
+            return "count:"
+        case .Sum:
+            return "sum:"
+        case .Average:
+            return "average:"
+        }
+    }
+    
+    internal func name<T>(expressions: [Expression<T>]) -> String {
+        return "_".join(Array(zip(function().componentsSeparatedByString(":"), expressions))
+            .map{ $0.0 + "_" + $0.1.name() })
+    }
 }
 
-public struct Expression<V: ExpressionType>: ExpressionType {
+public struct Expression<V: ExpressionType>: Builder, ExpressionType {
     typealias ValueType = V.ValueType
     internal let builder: ExpressionBuilder
+    internal let nameBuilder: NameBuilder
 
     private init(value: V?) {
         let attributeType = Attribute(value: value)
         switch attributeType {
         case .This:
             builder = { NSExpression.expressionForEvaluatedObject() }
+            nameBuilder = { "self" }
         case .KeyPath(let keyPath):
             builder = { NSExpression(forKeyPath: keyPath) }
+            nameBuilder = { keyPath }
         case .Value(let value):
             builder = { NSExpression(forConstantValue: value) }
+            nameBuilder = { "\(value)" }
         case .Null:
             // unsupported at swift 1.2
             builder = { NSExpression(forConstantValue: NSNull()) }
+            nameBuilder = { "nil" }
         case .Unsupported:
             // TODO: throw exception
             builder = { NSExpression() }
+            nameBuilder = { "unsupported value" }
         }
     }
     
-    private init(builder: ExpressionBuilder) {
-        self.builder = builder
+    private init(lhs: Expression, rhs: Expression, type: ExpressionFunctionType) {
+        builder = { NSExpression(forFunction: type.function(), arguments: [lhs.expression(), rhs.expression()]) }
+        nameBuilder = { type.name([lhs, rhs]) }
+    }
+    
+    private init(hs: Expression, type: ExpressionFunctionType) {
+        builder = { NSExpression(forFunction: type.function(), arguments: [hs.expression()]) }
+        nameBuilder = { type.name([hs]) }
     }
     
     static func createExpression<E: ExpressionType where E.ValueType == V>(value: E?) -> Expression {
         if let expression = value as? Expression {
             return expression
         } else {
-            return Expression(value: value as? V)
+            return Expression(value: value as? V ?? unsafeBitCast(value, Optional.self))
         }
-    }
-}
-
-extension Expression: Builder {
-    func build() -> NSExpression {
-        return builder()
     }
     
     public func expression() -> NSExpression {
         return builder()
     }
+    
+    public func name() -> String {
+        return nameBuilder()
+    }
 }
 
-public func +<E: ExpressionType>(lhs: E?, rhs: E?) -> Expression<E.ValueType> {
-    return Expression(builder: { NSExpression(forFunction: "add:to:", arguments: [Expression.createExpression(lhs).expression(), Expression.createExpression(rhs).expression()]) })
+public func +<E1: ExpressionType, E2: ExpressionType where E1.ValueType == NSNumber, E2.ValueType == NSNumber>(lhs: E1?, rhs: E2?) -> Expression<NSNumber> {
+    return Expression(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .Add)
 }
 
+public func -<E1: ExpressionType, E2: ExpressionType where E1.ValueType == NSNumber, E2.ValueType == NSNumber>(lhs: E1?, rhs: E2?) -> Expression<NSNumber> {
+    return Expression(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .Subtract)
+}
+
+public func *<E1: ExpressionType, E2: ExpressionType where E1.ValueType == NSNumber, E2.ValueType == NSNumber>(lhs: E1?, rhs: E2?) -> Expression<NSNumber> {
+    return Expression(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .Multiply)
+}
+
+public func /<E1: ExpressionType, E2: ExpressionType where E1.ValueType == NSNumber, E2.ValueType == NSNumber>(lhs: E1?, rhs: E2?) -> Expression<NSNumber> {
+    return Expression(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .Divide)
+}
+
+public func max<E: ExpressionType where E.ValueType == NSNumber>(hs: E?) -> Expression<NSNumber> {
+    return Expression(hs: Expression.createExpression(hs), type: .Max)
+}
+
+public func min<E: ExpressionType where E.ValueType == NSNumber>(hs: E?) -> Expression<NSNumber> {
+    return Expression(hs: Expression.createExpression(hs), type: .Min)
+}
+
+public func sum<E: ExpressionType where E.ValueType == NSNumber>(hs: E?) -> Expression<NSNumber> {
+    return Expression(hs: Expression.createExpression(hs), type: .Sum)
+}
+
+public func average<E: ExpressionType where E.ValueType == NSNumber>(hs: E?) -> Expression<NSNumber> {
+    return Expression(hs: Expression.createExpression(hs), type: .Average)
+}
+
+public func count<E: ExpressionType>(hs: E?) -> Expression<E.ValueType> {
+    return Expression(hs: Expression.createExpression(hs), type: .Count)
+}

--- a/Barrel/ExpressionDescription.swift
+++ b/Barrel/ExpressionDescription.swift
@@ -9,91 +9,22 @@
 import Foundation
 import CoreData
 
-private enum FunctionType {
-    case Max
-    case Min
-    case Count
-    case Sum
-    case Average
-    
-    private func function() -> String {
-        switch self {
-        case .Max:
-            return "max"
-        case .Min:
-            return "min"
-        case .Count:
-            return "count"
-        case .Sum:
-            return "sum"
-        case .Average:
-            return "average"
-        }
-    }
-}
-
 internal typealias ExpressionDescriptionBuilder = () -> NSExpressionDescription
 
-public struct ExpressionDescription<T: NSManagedObject>: Builder {
-    private let context: NSManagedObjectContext
+internal struct ExpressionDescription<T: NSManagedObject>: Builder {
     internal let builder: ExpressionDescriptionBuilder
-    internal init(context: NSManagedObjectContext) {
-        self.context = context
+    
+    internal init<V>(argument: Expression<V>) {
         builder = { () -> NSExpressionDescription in
             let expressionDescription = NSExpressionDescription()
+            expressionDescription.expression = argument.expression()
+            expressionDescription.name = argument.name()
+            expressionDescription.expressionResultType = NSAttributeType(type: V.self)
             return expressionDescription
         }
     }
-    private init(context: NSManagedObjectContext, description: ExpressionDescriptionBuilder) {
-        self.context = context
-        self.builder = description
-    }
-    
-    public func expressionDescription() -> NSExpressionDescription {
-        return builder()
-    }
-}
 
-extension ExpressionDescription {
-    private func _function<U>(type: FunctionType, argument: Expression<U>) -> ExpressionDescriptionBuilder {
-        return builder >>> { (expressionDescription: NSExpressionDescription) -> NSExpressionDescription in
-            let argument = argument.expression()
-            let entityDescription = self.context.entityDescription(T)!
-            expressionDescription.expression = NSExpression(forFunction: type.function() + ":", arguments: [argument])
-            expressionDescription.name = type.function() + argument.keyPath.capitalizedString
-            expressionDescription.expressionResultType = NSAttributeType(entityDescription: entityDescription, keyPath: argument.keyPath)
-            return expressionDescription
-        }
-    }
-    
-    internal func keyPath<U>(argument: Expression<U>) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: builder >>> { (expressionDescription: NSExpressionDescription) -> NSExpressionDescription in
-            let argument = argument.expression()
-            let entityDescription = self.context.entityDescription(T)!
-            expressionDescription.expression = argument
-            expressionDescription.name = argument.keyPath
-            expressionDescription.expressionResultType = NSAttributeType(entityDescription: entityDescription, keyPath: argument.keyPath)
-            return expressionDescription
-            })
-    }
-    
-    public func max<E: ExpressionType>(argument: E) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: _function(.Max, argument: Expression.createExpression(argument)))
-    }
-    
-    public func min<E: ExpressionType>(argument: E) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: _function(.Min, argument: Expression.createExpression(argument)))
-    }
-    
-    public func count<E: ExpressionType>(argument: E) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: _function(.Count, argument: Expression.createExpression(argument)))
-    }
-    
-    public func sum<E: ExpressionType>(argument: E) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: _function(.Sum, argument: Expression.createExpression(argument)))
-    }
-    
-    public func average<E: ExpressionType>(argument: E) -> ExpressionDescription {
-        return ExpressionDescription(context: context, description: _function(.Average, argument: Expression.createExpression(argument)))
+    internal func expressionDescription() -> NSExpressionDescription {
+        return builder()
     }
 }

--- a/Barrel/Fetch.swift
+++ b/Barrel/Fetch.swift
@@ -115,15 +115,9 @@ public extension Fetch {
         return orderBy(sortDescriptor(self.context.attribute(), self.context.comparison()).sortDescriptor())
     }
     
-    public func aggregate(expressionDescription:(ExpressionDescription<T>, T) -> ExpressionDescription<T>) -> Aggregate<T> {
-        return aggregate(expressionDescription(ExpressionDescription(context: context), self.context.attribute()).expressionDescription())
-    }
-    
-    public func aggregate<E: ExpressionType>(expressionDescription:(ExpressionDescription<T>, T) -> E) -> Aggregate<T> {
+    public func aggregate<E: ExpressionType>(expressionDescription:(T) -> E) -> Aggregate<T> {
         return aggregate({ () -> NSExpressionDescription in
-            let description = ExpressionDescription<T>(context: self.context)
-            let result = Expression.createExpression(expressionDescription(description, self.context.attribute()))
-            return description.keyPath(result).expressionDescription()
+            return ExpressionDescription(argument: Expression.createExpression(expressionDescription(self.context.attribute()))).expressionDescription()
         }())
     }
 }

--- a/Barrel/Group.swift
+++ b/Barrel/Group.swift
@@ -64,16 +64,7 @@ public extension Group {
         return having(predicate(self.context.attribute()).predicate())
     }
     
-    public func groupBy<U>(keyPath: (T) -> U) -> Group {
-        return groupBy({
-            if let attribute = (keyPath(self.context.attribute()) as? String)?.decodingProperty() {
-                return attribute.keyPath
-            }
-            return ""
-            }())
-    }
-    
-    public func groupBy<U>(keyPath: (T) -> Expression<U>) -> Group {
-        return groupBy(keyPath(self.context.attribute()).expression().keyPath)
+    public func groupBy<E: ExpressionType>(argument: (T) -> E) -> Group {
+        return groupBy(Expression.createExpression(argument(self.context.attribute())).name())
     }
 }

--- a/Barrel/Info.plist
+++ b/Barrel/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.2</string>
+	<string>0.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Barrel/Predicate.swift
+++ b/Barrel/Predicate.swift
@@ -29,31 +29,31 @@ private extension Predicate {
     }
 }
 
-public func ==<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func ==<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .EqualToPredicateOperatorType)
 }
 
-public func !=<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func !=<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .NotEqualToPredicateOperatorType)
 }
 
-public func ~=<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func ~=<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .LikePredicateOperatorType)
 }
 
-public func ><E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func ><E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .GreaterThanPredicateOperatorType)
 }
 
-public func >=<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func >=<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .GreaterThanOrEqualToPredicateOperatorType)
 }
 
-public func <<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func <<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .LessThanPredicateOperatorType)
 }
 
-public func <=<E: ExpressionType>(lhs: E?, rhs: E?) -> Predicate {
+public func <=<E1: ExpressionType, E2: ExpressionType, V: ExpressionType where E1.ValueType == V, E2.ValueType == V>(lhs: E1?, rhs: E2?) -> Predicate {
     return Predicate(lhs: Expression.createExpression(lhs), rhs: Expression.createExpression(rhs), type: .LessThanOrEqualToPredicateOperatorType)
 }
 

--- a/BarrelTests/AggregateTest.swift
+++ b/BarrelTests/AggregateTest.swift
@@ -35,19 +35,19 @@ class AggregateTest: XCTestCase {
     }
     
     func testFetchAggregate() {
-        let maxs = context.fetch(Person).aggregate{ $0.max($1.age) }.aggregate({ $1.name }).execute().all()
+        let maxs = context.fetch(Person).aggregate{ max($0.age) }.aggregate({ $0.name }).execute().all()
         for max in maxs {
-            XCTAssertEqual(max["maxAge"] as! Int, 39, "Pass")
+            XCTAssertEqual(max["max_age"] as! Int, 39, "Pass")
         }
     }
     
     func testFetchGroupBy() {
-        let maxs = context.fetch(Person).aggregate{ $0.max($1.age) }.aggregate({ $1.name }).groupBy{ $0.name }.execute().all()
+        let maxs = context.fetch(Person).aggregate{ max($0.age) }.aggregate({ $0.name }).groupBy{ $0.name }.execute().all()
         XCTAssertEqual(maxs.count, 2, "Pass")
     }
     
     func testFetchHaving() {
-        let maxs = context.fetch(Person).aggregate{ $0.max($1.age) }.aggregate({ $1.name }).groupBy{ $0.name }.having{ $0.age > 30 }.execute().all()
+        let maxs = context.fetch(Person).aggregate{ max($0.age) }.aggregate({ $0.name }).groupBy{ $0.name }.having{ $0.age > 30 }.execute().all()
         XCTAssertEqual(maxs.count, 1, "Pass")
     }
 }

--- a/BarrelTests/AttributeTest.swift
+++ b/BarrelTests/AttributeTest.swift
@@ -46,8 +46,6 @@ class AttributeTest: XCTestCase {
         XCTAssertNotNil(managerFetchRequest.predicate, "Pass")
         XCTAssertEqual(managerFetchRequest.predicate!, NSCompoundPredicate(type: .AndPredicateType, subpredicates: [NSPredicate(value: true), NSPredicate(format: "post == %@", "manager")]), "Pass")
 
-        // swift Set object comparison is unsupported at swift 1.2
-        // Use NSSet object.
         let noChildrenFetchRequest = context.fetch(Person).filter{ $0.children == Set<Person>() }.fetchRequest()
         XCTAssertNotNil(noChildrenFetchRequest.predicate, "Pass")
         XCTAssertEqual(noChildrenFetchRequest.predicate!, NSCompoundPredicate(type: .AndPredicateType, subpredicates: [NSPredicate(value: true), NSPredicate(format: "children == %@", Set<Person>())]), "Pass")

--- a/BarrelTests/AttributeTest.swift
+++ b/BarrelTests/AttributeTest.swift
@@ -30,7 +30,6 @@ class AttributeTest: XCTestCase {
     }
 
     func testAttributeInFetch() {
-        let e: Expression<NSNumber> = 20 + 5
         let personFetchRequest = context.fetch(Person).filter{ $0.name == "John" && $0.age == 20 }.orderBy{ $0.age < $1.age }.fetchRequest()
         XCTAssertNotNil(personFetchRequest.predicate, "Pass")
         XCTAssertEqual(personFetchRequest.predicate!, NSCompoundPredicate(type: .AndPredicateType, subpredicates: [NSPredicate(value: true), NSPredicate(format: "name == %@ && age == %i", "John", 20)]), "Pass")
@@ -49,7 +48,7 @@ class AttributeTest: XCTestCase {
 
         // swift Set object comparison is unsupported at swift 1.2
         // Use NSSet object.
-        let noChildrenFetchRequest = context.fetch(Person).filter{ $0.children == NSSet() }.fetchRequest()
+        let noChildrenFetchRequest = context.fetch(Person).filter{ $0.children == Set<Person>() }.fetchRequest()
         XCTAssertNotNil(noChildrenFetchRequest.predicate, "Pass")
         XCTAssertEqual(noChildrenFetchRequest.predicate!, NSCompoundPredicate(type: .AndPredicateType, subpredicates: [NSPredicate(value: true), NSPredicate(format: "children == %@", Set<Person>())]), "Pass")
         

--- a/BarrelTests/AttributeTest.swift
+++ b/BarrelTests/AttributeTest.swift
@@ -30,6 +30,7 @@ class AttributeTest: XCTestCase {
     }
 
     func testAttributeInFetch() {
+        let e: Expression<NSNumber> = 20 + 5
         let personFetchRequest = context.fetch(Person).filter{ $0.name == "John" && $0.age == 20 }.orderBy{ $0.age < $1.age }.fetchRequest()
         XCTAssertNotNil(personFetchRequest.predicate, "Pass")
         XCTAssertEqual(personFetchRequest.predicate!, NSCompoundPredicate(type: .AndPredicateType, subpredicates: [NSPredicate(value: true), NSPredicate(format: "name == %@ && age == %i", "John", 20)]), "Pass")


### PR DESCRIPTION
Adding arithmetic operation in Expression.

``` swift
class Physical: NSManagedObject {
  @NSManaged var height: NSNumber
  @NSManaged var weight: NSNumber
}
context.fetch(Physical).filter{ $0.weight / $0.height / $0.height > 22 }.execute().all()
```

More Simply aggregate

``` swift
context.fetch(Person).aggregate{ $0.name }.aggregate{ max($0.age) }.groupBy{ $0.name }.execute().all()
```

Fix cannot use Set<NSManagedObject> in filter and other.

``` swift
context.fetch(Person).filter{ $0.children == Set<Person>() }.execute().all()
```
