### PR TITLE
change all api for swift 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ matrix:
   include:
     - os: osx
       language: objective-c
-      osx_image: xcode7.2
+      osx_image: xcode7.3
 # before_install:
 #   - carthage bootstrap --verbose
 script:

--- a/Core/Attribute.swift
+++ b/Core/Attribute.swift
@@ -9,14 +9,15 @@
 import Foundation
 
 public protocol AttributeType: ExpressionType {
-    typealias FieldType
+    associatedtype SourceType: ExpressionType
+    associatedtype ValueType = SourceType.ValueType
     var keyPath: KeyPath { get }
     init(name: String?, parentName: String?)
 }
 
 public struct Attribute<T: ExpressionType>: AttributeType {
-    public typealias FieldType = T
-    public typealias ValueType = T.ValueType
+    public typealias SourceType = T
+    public typealias ValueType = SourceType.ValueType
     
     public let keyPath: KeyPath
     
@@ -26,23 +27,15 @@ public struct Attribute<T: ExpressionType>: AttributeType {
     }
 }
 
-public struct OptionalAttribute<T: ExpressionType>: AttributeType {
-    public typealias FieldType = T
-    public typealias ValueType = T.ValueType
-    
-    public let keyPath: KeyPath
-    
-    @available(*, unavailable)
-    public init(name: String? = nil, parentName: String? = nil) {
-        self.keyPath = KeyPath(name, parentName: parentName)
-    }
+extension Optional: ExpressionType {
+    public typealias ValueType = Wrapped
 }
 
 public func storedAttribute<T: AttributeType>(name: String? = nil) -> T {
     return AttributeStorage.sharedInstance.attribute(name, parent: Optional<T>.None)
 }
 
-public func storedAttribute<T: AttributeType, U : AttributeType>(name: String = __FUNCTION__, parent: U) -> T {
+public func storedAttribute<T: AttributeType, U : AttributeType>(name: String = #function, parent: U) -> T {
     return AttributeStorage.sharedInstance.attribute(name, parent: parent)
 }
 

--- a/Core/Expression.swift
+++ b/Core/Expression.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public protocol ExpressionType {
-    typealias ValueType
+    associatedtype ValueType
 }
 
 enum ExpressionFunction: String {

--- a/Core/Predicate.swift
+++ b/Core/Predicate.swift
@@ -129,7 +129,7 @@ public prefix func !(hs: PredicateType) -> Predicate {
     return Predicate(hs: hs, type: .NotPredicateType)
 }
 
-extension AttributeType where ValueType == String, FieldType == String {
+extension AttributeType where ValueType == String {
     public func contains<E: ExpressionType, P: PredicateType where E.ValueType == String>(other: E) -> P {
         return P(lhs: self, rhs: other, type: .ContainsPredicateOperatorType, options: [])
     }
@@ -152,26 +152,26 @@ extension AttributeType where ValueType == String, FieldType == String {
 }
 
 public protocol ManyType: ExpressionType {
-    typealias ElementType: ExpressionType
+    associatedtype ElementType: ExpressionType
 }
 
-extension AttributeType where FieldType: ManyType {
-    public func any(f: Attribute<FieldType.ElementType> -> AnyPredicate) -> Predicate {
+extension AttributeType where SourceType: ManyType {
+    public func any(f: Attribute<SourceType.ElementType> -> AnyPredicate) -> Predicate {
         return Predicate(f(storedAttribute(self.keyPath.string)).value)
     }
     
-    public func all(f: Attribute<FieldType.ElementType> -> AllPredicate) -> Predicate {
+    public func all(f: Attribute<SourceType.ElementType> -> AllPredicate) -> Predicate {
         return Predicate(f(storedAttribute(self.keyPath.string)).value)
     }
 }
 
-extension OptionalAttribute where T.ValueType: ExpressionType {
+extension AttributeType where ValueType: ExpressionType, SourceType == Optional<ValueType> {
     public func isNull<P: PredicateType>() -> P {
-        return P(lhs: self, rhs: Expression<T>(NSExpression(forConstantValue: nil)), type: .EqualToPredicateOperatorType, options: [])
+        return P(lhs: self, rhs: Expression<SourceType>(NSExpression(forConstantValue: nil)), type: .EqualToPredicateOperatorType, options: [])
     }
     
     public func isNotNull<P: PredicateType>() -> P {
-        return P(lhs: self, rhs: Expression<T>(NSExpression(forConstantValue: nil)), type: .NotEqualToPredicateOperatorType, options: [])
+        return P(lhs: self, rhs: Expression<SourceType>(NSExpression(forConstantValue: nil)), type: .NotEqualToPredicateOperatorType, options: [])
     }
 }
 

--- a/Core/Protocols.swift
+++ b/Core/Protocols.swift
@@ -31,7 +31,7 @@ public func ><C: NSComparable>(lhs: C, rhs: C) -> Bool {
 }
 
 public protocol SelfExpression : ExpressionType {
-    typealias ValueType = Self
+    associatedtype ValueType = Self
 }
 
 extension Double : SelfExpression, NumberType {}

--- a/Core/Tests/BarrelTests.swift
+++ b/Core/Tests/BarrelTests.swift
@@ -21,11 +21,11 @@ struct Many<T: ExpressionType>: ManyType {
     typealias ElementType = T
 }
 
-extension AttributeType where FieldType == TestModel {
+extension AttributeType where ValueType == TestModel {
     var text: Attribute<String> { return storedAttribute(parent: self) }
     var number: Attribute<Int> { return storedAttribute(parent: self) }
     var array: Attribute<Many<Int>> { return storedAttribute(parent: self) }
-    var option: OptionalAttribute<Int> { return storedAttribute(parent: self) }
+    var option: Attribute<Optional<Int>> { return storedAttribute(parent: self) }
 }
 
 class BarrelTests: XCTestCase {

--- a/CoreData/Builder.swift
+++ b/CoreData/Builder.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol BuilderType {
-    typealias Result
+    associatedtype Result
     func build() -> Result
 }
 

--- a/CoreData/Executable.swift
+++ b/CoreData/Executable.swift
@@ -10,10 +10,10 @@ import Foundation
 import CoreData
 
 public protocol Executable: CollectionType, Indexable {
-    typealias Type
-    typealias GeneratorType = AnyGenerator<Type>
-    typealias SubSquence = ArraySlice<Type>
-    typealias Index = Int
+    associatedtype Type
+    associatedtype GeneratorType = AnyGenerator<Type>
+    associatedtype SubSquence = ArraySlice<Type>
+    associatedtype Index = Int
     var context: NSManagedObjectContext { get }
     func fetchRequest() -> NSFetchRequest
 }
@@ -63,13 +63,14 @@ extension Executable {
 extension Executable {
     public func generate() -> AnyGenerator<Type> {
         var count = 0
-        return anyGenerator({ () -> Type? in
+        return AnyGenerator { () -> Type? in
             do {
-                return try self.get(count++)
+                count += 1
+                return try self.get(count)
             } catch {
                 return nil
             }
-        })
+        }
     }
     
     public func underestimateCount() -> Int {

--- a/CoreData/Extensions.swift
+++ b/CoreData/Extensions.swift
@@ -76,13 +76,9 @@ public struct Many<T: NSManagedObject where T: ExpressionType>: ExpressionType, 
     public typealias ElementType = T
 }
 
-public protocol ManagedObjectType: ExpressionType {
-    typealias ValueType = Self
-}
-
-extension NSManagedObject: ManagedObjectType {}
-
-public extension ManagedObjectType where Self: NSManagedObject {
+extension ExpressionType where Self: NSManagedObject {
+    public typealias ValueType = Self
+    
     static func objects(context: NSManagedObjectContext) -> Fetch<Self> {
         return Fetch(context: context)
     }
@@ -90,4 +86,8 @@ public extension ManagedObjectType where Self: NSManagedObject {
     static func insert(context: NSManagedObjectContext) -> Self {
         return Self(entity: context.entityDescription(Self)!, insertIntoManagedObjectContext: context)
     }
+}
+
+extension NSManagedObject: ExpressionType {
+    public typealias ValueType = NSManagedObject
 }

--- a/CoreData/Readme.md
+++ b/CoreData/Readme.md
@@ -12,7 +12,7 @@ var fetches = Person.objects(self.context)
 
 Plese write AttributeType extensions.
 ```swift
-extension AttributeType where FieldType: Person {
+extension AttributeType where ValueType: Person {
     var name: Attribute<String> { return storedAttribute(parent: self) }
     var age: Attribute<Int> { return storedAttribute(parent: self) }
 }
@@ -45,7 +45,7 @@ var maxAgeGroupByName = Person.objects(self.context)
 ## Relationships
 Your model has many-relationships, use Many type in Attribute like.
 ```swift
-extension AttributeType where FieldType: Planet {
+extension AttributeType where ValueType: Planet {
     var name: Attribute<String> { return storedAttribute(parent: self) }
     var children: Attribute<Many<Satellite>> { return storedAttribute(parent: self) }
 }

--- a/CoreData/Tests/BarrelCoreDataTests.swift
+++ b/CoreData/Tests/BarrelCoreDataTests.swift
@@ -138,7 +138,7 @@ class BarrelCoreDataTests: XCTestCase {
         XCTAssertEqual(fetch.filter { $0.diameter > 100000 }.count, 2)
         var i = 0
         fetch.forEach {
-            i++
+            i += 1
             XCTAssert($0.isKindOfClass(Planet.self))
         }
         XCTAssertEqual(i, 6)

--- a/CoreData/Tests/Planet+BarrelAttribute.swift
+++ b/CoreData/Tests/Planet+BarrelAttribute.swift
@@ -10,8 +10,8 @@ import Foundation
 import Barrel
 import Barrel_CoreData
 
-extension AttributeType where FieldType: Planet {
+extension AttributeType where ValueType: Planet {
     var semiMajorAxis: Attribute<NSNumber> { return storedAttribute(parent: self) }
-    var parent: OptionalAttribute<Star> { return storedAttribute(parent: self) }
+    var parent: Attribute<Optional<Star>> { return storedAttribute(parent: self) }
     var children: Attribute<Many<Satellite>> { return storedAttribute(parent: self) }
 }

--- a/CoreData/Tests/Satellite+BarrelAttribute.swift
+++ b/CoreData/Tests/Satellite+BarrelAttribute.swift
@@ -10,7 +10,7 @@ import Foundation
 import Barrel
 import Barrel_CoreData
 
-extension AttributeType where FieldType: Satellite {
+extension AttributeType where ValueType: Satellite {
     var semiMajorAxis: Attribute<NSNumber> { return storedAttribute(parent: self) }
-    var parent: OptionalAttribute<Planet> { return storedAttribute(parent: self) }
+    var parent: Attribute<Optional<Planet>> { return storedAttribute(parent: self) }
 }

--- a/CoreData/Tests/Star+BarrelAttribute.swift
+++ b/CoreData/Tests/Star+BarrelAttribute.swift
@@ -10,6 +10,6 @@ import Foundation
 import Barrel
 import Barrel_CoreData
 
-extension AttributeType where FieldType: Star {
+extension AttributeType where ValueType: Star {
     var children: Attribute<Many<Planet>> { return storedAttribute(parent: self) }
 }

--- a/CoreData/Tests/StarBase+BarrelAttribute.swift
+++ b/CoreData/Tests/StarBase+BarrelAttribute.swift
@@ -10,7 +10,7 @@ import Foundation
 import Barrel
 import Barrel_CoreData
 
-extension AttributeType where FieldType: StarBase {
+extension AttributeType where ValueType: StarBase {
     var diameter: Attribute<NSNumber> { return storedAttribute(parent: self) }
     var name: Attribute<String> { return storedAttribute(parent: self) }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -21,10 +21,10 @@ class A: SelfExpression {
     var option: String?
 }
 
-extension AttributeType where FieldType: A {
+extension AttributeType where ValueType: A {
     var text: Attribute<String> { return storedAttribute(parent: self) }
     var number: Attribute<Int> { return storedAttribute(parent: self) }
-    var option: OptionalAttribute<String> { return storedAttribute(parent: self) }
+    var option: Attribute<Optional<String>> { return storedAttribute(parent: self) }
 }
 ```
 
@@ -37,8 +37,8 @@ var expression: Expression = attribute.number.max() // expression.value is NSExp
 
 ## Attribute
 
-Extend AttributeType using computed property one by one FieldType.
-Computed properties are Attribute<T>, or OptionalAttribute<T> and return "storedAttribute(parent: self)".
+Extend AttributeType using computed property one by one ValueType.
+Computed properties are Attribute<T> and return "storedAttribute(parent: self)".
 Get Attribute instance from "storedAttribute()".
 
 ## Expression
@@ -68,7 +68,7 @@ struct Many<T: ExpressionType>: ManyType {
     typealias ElementType = T
 }
 
-extension AttributeType where FieldType == A {
+extension AttributeType where ValueType == A {
     var array: Attribute<Many<A>> { return storedAttribute(parent: self) }
 }
 

--- a/Realm/Extensions.swift
+++ b/Realm/Extensions.swift
@@ -10,12 +10,12 @@ import Foundation
 import RealmSwift
 import Barrel
 
-extension Object : ExpressionType {
+extension Object: ExpressionType {
     public typealias ValueType = Object
 }
 
-public struct Many<T: Object where T: ExpressionType>: ExpressionType, ManyType {
-    public typealias ValueType = List<T>
+extension List: ExpressionType, ManyType {
+    public typealias ValueType = List
     public typealias ElementType = T
 }
 
@@ -31,11 +31,8 @@ public extension Realm {
     }
 }
 
-public protocol ObjectType {}
-
-extension Object: ObjectType {}
-
-public extension ObjectType where Self: Object {
+public extension ExpressionType where Self: Object {
+    public typealias ValueType = Self
     static func objects(realm: Realm) -> Results<Self> {
         return realm.objects()
     }

--- a/Realm/Readme.md
+++ b/Realm/Readme.md
@@ -12,7 +12,7 @@ var results = Person.objects(self.realm)
 
 Plese write AttributeType extensions.
 ```swift
-extension AttributeType where FieldType: Person {
+extension AttributeType where ValueType: Person {
     var name: Attribute<String> { return storedAttribute(parent: self) }
     var age: Attribute<Int> { return storedAttribute(parent: self) }
 }
@@ -30,7 +30,7 @@ var searchPersons = Person.objects(self.context)
 ## Relationships
 Your model has many-relationships, use Many type in Attribute like.
 ```swift
-extension AttributeType where FieldType: Planet {
+extension AttributeType where ValueType: Planet {
     var name: Attribute<String> { return storedAttribute(parent: self) }
     var children: Attribute<Many<Satellite>> { return storedAttribute(parent: self) }
 }

--- a/Realm/Tests/Planet.swift
+++ b/Realm/Tests/Planet.swift
@@ -21,7 +21,7 @@ class Planet: StarBase {
     }
 }
 
-extension AttributeType where FieldType: Planet {
+extension AttributeType where ValueType: Planet {
     var semiMajorAxis: Attribute<Double> { return storedAttribute(parent: self) }
-    var parent: OptionalAttribute<Star> { return storedAttribute(parent: self) }
+    var parent: Attribute<Optional<Star>> { return storedAttribute(parent: self) }
 }

--- a/Realm/Tests/Satellite.swift
+++ b/Realm/Tests/Satellite.swift
@@ -17,7 +17,7 @@ class Satellite: StarBase {
     dynamic var parent: Planet?
 }
 
-extension AttributeType where FieldType: Satellite {
+extension AttributeType where ValueType: Satellite {
     var semiMajorAxis: Attribute<Double> { return storedAttribute(parent: self) }
-    var parent: OptionalAttribute<Planet> { return storedAttribute(parent: self) }
+    var parent: Attribute<Optional<Planet>> { return storedAttribute(parent: self) }
 }

--- a/Realm/Tests/Star.swift
+++ b/Realm/Tests/Star.swift
@@ -17,5 +17,5 @@ class Star: StarBase {
     }
 }
 
-extension AttributeType where FieldType: Star {
+extension AttributeType where ValueType: Star {
 }

--- a/Realm/Tests/StarBase.swift
+++ b/Realm/Tests/StarBase.swift
@@ -16,7 +16,7 @@ class StarBase: Object {
     dynamic var diameter: Double = 0.0
 }
 
-extension AttributeType where FieldType: StarBase {
+extension AttributeType where ValueType: StarBase {
     var name: Attribute<String> { return storedAttribute(parent: self) }
     var diameter: Attribute<Double> { return storedAttribute(parent: self) }
 }


### PR DESCRIPTION
Now swift2.2 fixed protocol bugs, 
So we can use more convenient type than swift2.1.

There is 2 big changes.
- We use `ValueType` instead of `FieldType` in `AttributeType` extension.
- We use `Attribute<Optional<T>>` instead of `OptionalAttribute<T>`.
