### PR TITLE
Add new attribute() syntax sugar.

### DIFF
--- a/Core/Attribute.swift
+++ b/Core/Attribute.swift
@@ -15,6 +15,12 @@ public protocol AttributeType: ExpressionType {
     init(name: String?, parentName: String?)
 }
 
+public extension AttributeType {
+    func attribute<T: ExpressionType>(name: String = #function) -> Attribute<T> {
+        return storedAttribute(name, parent: self)
+    }
+}
+
 public struct Attribute<T: ExpressionType>: AttributeType {
     public typealias SourceType = T
     public typealias ValueType = SourceType.ValueType

--- a/Core/Tests/BarrelTests.swift
+++ b/Core/Tests/BarrelTests.swift
@@ -22,10 +22,10 @@ struct Many<T: ExpressionType>: ManyType {
 }
 
 extension AttributeType where ValueType == TestModel {
-    var text: Attribute<String> { return storedAttribute(parent: self) }
-    var number: Attribute<Int> { return storedAttribute(parent: self) }
-    var array: Attribute<Many<Int>> { return storedAttribute(parent: self) }
-    var option: Attribute<Optional<Int>> { return storedAttribute(parent: self) }
+    var text: Attribute<String> { return attribute() }
+    var number: Attribute<Int> { return attribute() }
+    var array: Attribute<Many<Int>> { return attribute() }
+    var option: Attribute<Optional<Int>> { return attribute() }
 }
 
 class BarrelTests: XCTestCase {

--- a/CoreData/Readme.md
+++ b/CoreData/Readme.md
@@ -13,8 +13,8 @@ var fetches = Person.objects(self.context)
 Plese write AttributeType extensions.
 ```swift
 extension AttributeType where ValueType: Person {
-    var name: Attribute<String> { return storedAttribute(parent: self) }
-    var age: Attribute<Int> { return storedAttribute(parent: self) }
+    var name: Attribute<String> { return attribute() }
+    var age: Attribute<Int> { return attribute() }
 }
 ```
 
@@ -46,6 +46,6 @@ var maxAgeGroupByName = Person.objects(self.context)
 Your model has many-relationships, use Many type in Attribute like.
 ```swift
 extension AttributeType where ValueType: Planet {
-    var name: Attribute<String> { return storedAttribute(parent: self) }
-    var children: Attribute<Many<Satellite>> { return storedAttribute(parent: self) }
+    var name: Attribute<String> { return attribute() }
+    var children: Attribute<Many<Satellite>> { return attribute() }
 }

--- a/CoreData/Tests/Satellite+BarrelAttribute.swift
+++ b/CoreData/Tests/Satellite+BarrelAttribute.swift
@@ -11,6 +11,6 @@ import Barrel
 import Barrel_CoreData
 
 extension AttributeType where ValueType: Satellite {
-    var semiMajorAxis: Attribute<NSNumber> { return storedAttribute(parent: self) }
-    var parent: Attribute<Optional<Planet>> { return storedAttribute(parent: self) }
+    var semiMajorAxis: Attribute<NSNumber> { return attribute() }
+    var parent: Attribute<Optional<Planet>> { return attribute() }
 }

--- a/CoreData/Tests/Star+BarrelAttribute.swift
+++ b/CoreData/Tests/Star+BarrelAttribute.swift
@@ -11,5 +11,5 @@ import Barrel
 import Barrel_CoreData
 
 extension AttributeType where ValueType: Star {
-    var children: Attribute<Many<Planet>> { return storedAttribute(parent: self) }
+    var children: Attribute<Many<Planet>> { return attribute() }
 }

--- a/CoreData/Tests/StarBase+BarrelAttribute.swift
+++ b/CoreData/Tests/StarBase+BarrelAttribute.swift
@@ -11,6 +11,6 @@ import Barrel
 import Barrel_CoreData
 
 extension AttributeType where ValueType: StarBase {
-    var diameter: Attribute<NSNumber> { return storedAttribute(parent: self) }
-    var name: Attribute<String> { return storedAttribute(parent: self) }
+    var diameter: Attribute<NSNumber> { return attribute() }
+    var name: Attribute<String> { return attribute() }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -22,9 +22,9 @@ class A: SelfExpression {
 }
 
 extension AttributeType where ValueType: A {
-    var text: Attribute<String> { return storedAttribute(parent: self) }
-    var number: Attribute<Int> { return storedAttribute(parent: self) }
-    var option: Attribute<Optional<String>> { return storedAttribute(parent: self) }
+    var text: Attribute<String> { return attribute() }
+    var number: Attribute<Int> { return attribute() }
+    var option: Attribute<Optional<String>> { return attribute() }
 }
 ```
 
@@ -38,7 +38,7 @@ var expression: Expression = attribute.number.max() // expression.value is NSExp
 ## Attribute
 
 Extend AttributeType using computed property one by one ValueType.
-Computed properties are Attribute<T> and return "storedAttribute(parent: self)".
+Computed properties are Attribute<T> and return "attribute()".
 Get Attribute instance from "storedAttribute()".
 
 ## Expression
@@ -69,7 +69,7 @@ struct Many<T: ExpressionType>: ManyType {
 }
 
 extension AttributeType where ValueType == A {
-    var array: Attribute<Many<A>> { return storedAttribute(parent: self) }
+    var array: Attribute<Many<A>> { return attribute() }
 }
 
 var anyPredicate: Predicate = attribute.array.any { $0.number > 0 }

--- a/Realm/Readme.md
+++ b/Realm/Readme.md
@@ -13,8 +13,8 @@ var results = Person.objects(self.realm)
 Plese write AttributeType extensions.
 ```swift
 extension AttributeType where ValueType: Person {
-    var name: Attribute<String> { return storedAttribute(parent: self) }
-    var age: Attribute<Int> { return storedAttribute(parent: self) }
+    var name: Attribute<String> { return attribute() }
+    var age: Attribute<Int> { return attribute() }
 }
 ```
 
@@ -31,6 +31,6 @@ var searchPersons = Person.objects(self.context)
 Your model has many-relationships, use Many type in Attribute like.
 ```swift
 extension AttributeType where ValueType: Planet {
-    var name: Attribute<String> { return storedAttribute(parent: self) }
-    var children: Attribute<Many<Satellite>> { return storedAttribute(parent: self) }
+    var name: Attribute<String> { return attribute() }
+    var children: Attribute<Many<Satellite>> { return attribute() }
 }

--- a/Realm/Tests/Planet.swift
+++ b/Realm/Tests/Planet.swift
@@ -22,6 +22,6 @@ class Planet: StarBase {
 }
 
 extension AttributeType where ValueType: Planet {
-    var semiMajorAxis: Attribute<Double> { return storedAttribute(parent: self) }
-    var parent: Attribute<Optional<Star>> { return storedAttribute(parent: self) }
+    var semiMajorAxis: Attribute<Double> { return attribute() }
+    var parent: Attribute<Optional<Star>> { return attribute() }
 }

--- a/Realm/Tests/Satellite.swift
+++ b/Realm/Tests/Satellite.swift
@@ -18,6 +18,6 @@ class Satellite: StarBase {
 }
 
 extension AttributeType where ValueType: Satellite {
-    var semiMajorAxis: Attribute<Double> { return storedAttribute(parent: self) }
-    var parent: Attribute<Optional<Planet>> { return storedAttribute(parent: self) }
+    var semiMajorAxis: Attribute<Double> { return attribute() }
+    var parent: Attribute<Optional<Planet>> { return attribute() }
 }

--- a/Realm/Tests/StarBase.swift
+++ b/Realm/Tests/StarBase.swift
@@ -17,6 +17,6 @@ class StarBase: Object {
 }
 
 extension AttributeType where ValueType: StarBase {
-    var name: Attribute<String> { return storedAttribute(parent: self) }
-    var diameter: Attribute<Double> { return storedAttribute(parent: self) }
+    var name: Attribute<String> { return attribute() }
+    var diameter: Attribute<Double> { return attribute() }
 }


### PR DESCRIPTION
before

``` swift
extension AttributeType where ValueType: Person {
    var name: Attribute<String> { return storedAttribute(parent: self) }
    var age: Attribute<Int> { return storedAttribute(parent: self) }
}
```

after

``` swift
extension AttributeType where ValueType: Person {
    var name: Attribute<String> { return attribute() }
    var age: Attribute<Int> { return attribute() }
}
```

It seems good :+1: 
